### PR TITLE
Fix for the 'too many open files' error.

### DIFF
--- a/lib/PeakRescue.pm
+++ b/lib/PeakRescue.pm
@@ -3,7 +3,7 @@ use strict;
 use Const::Fast qw(const);
 
 use base 'Exporter';
-our $VERSION = '3.2.6';
+our $VERSION = '3.2.7';
 our @EXPORT = qw($VERSION);
 const my $LICENSE =>
 "#################


### PR DESCRIPTION
New release fixing issue to do with 'too many open files' by removing the -fasta option while creating Bio::DB::Sam objects.
